### PR TITLE
Add autobenchmark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
                 <canvas id="webgpu-canvas" class="img-fluid" width="1920" height="1088"></canvas>
             </div>
             <div class="col-12 col-lg-8 mx-auto row">
-                <div class="col-12 text-center" id="autobenchmark-complete" hidden>
-                    <h3>Autobenchmark Complete!</h3>
+                <div class="col-12 text-center" id="autobenchmark-status-div" hidden>
+                    <h3 id="autobenchmark-status"></h3>
                 </div>
                 <div class="form-group col-8">
                     <label for="isovalue">Isovalue</label>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,9 @@
                 <canvas id="webgpu-canvas" class="img-fluid" width="1920" height="1088"></canvas>
             </div>
             <div class="col-12 col-lg-8 mx-auto row">
+                <div class="col-12 text-center" id="autobenchmark-complete" hidden>
+                    <h3>Autobenchmark Complete!</h3>
+                </div>
                 <div class="form-group col-8">
                     <label for="isovalue">Isovalue</label>
                     <input type="range" class="form-control-range" id="isovalue" min="0.0" max="255.0" step="1">
@@ -40,7 +43,7 @@
                     <label for="outputImages">Output Images</label>
                 </div>
                 <div class="form-group col-3">
-                    <input type="checkbox" checked class="form-check-input" id="colorActive">
+                    <input type="checkbox" class="form-check-input" id="colorActive">
                     <label for="colorActive">Color Active Rays</label>
                 </div>
                 <div class="form-group col-3">

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
                     <label for="outputImages">Output Images</label>
                 </div>
                 <div class="form-group col-3">
-                    <input type="checkbox" class="form-check-input" id="colorActive">
+                    <input type="checkbox" class="form-check-input" id="colorActive" checked>
                     <label for="colorActive">Color Active Rays</label>
                 </div>
                 <div class="form-group col-3">

--- a/src/app.js
+++ b/src/app.js
@@ -625,7 +625,14 @@ import {InferenceSession} from "onnxruntime-web/webgpu";
             if (surfaceDone) {
                 perfStats.push(
                     {
-                        "isovalue": currentIsovalue, "stats": volumeRC.surfacePerfStats, "inferenceTime": inferenceTime
+                        "isovalue": currentIsovalue,
+                        "stats": volumeRC.surfacePerfStats,
+                        "inferenceTime": inferenceTime,
+                        "config": {
+                            "resolution": [width, height],
+                            "startSpecCount": headstartSlider.value,
+                            "completenessThreshold": completenessThreshold.value,
+                        }
                     });
             }
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,31 +1,28 @@
-import { datasets, getVolumeDimensions } from "./volumes";
-import { VolumeRaycaster } from "./volume_raycaster";
-import { RandomIsovalueBenchmark, ManualSingleBenchmark, SweepIsovalueBenchmark, NestedBenchmark, RotateBenchmark} from './run_benchmark';
-import { Controller, ArcballCamera } from "./webgl-util";
-import { display_render_frag_spv, display_render_vert_spv } from "./embedded_shaders";
-import { vec3, mat4 } from "gl-matrix";
-import { saveAs } from 'file-saver';
-import { imageDataToTensor, runInference, getImageTensorFromPath, cleanRecurrentState } from "./inference";
-import { InferenceSession } from "onnxruntime-web/webgpu";
+import {datasets, getVolumeDimensions} from "./volumes";
+import {VolumeRaycaster} from "./volume_raycaster";
+import {RandomIsovalueBenchmark, ManualSingleBenchmark, SweepIsovalueBenchmark, NestedBenchmark, RotateBenchmark, generateBenchmarkConfigurations} from './run_benchmark';
+import {Controller, ArcballCamera} from "./webgl-util";
+import {display_render_frag_spv, display_render_vert_spv} from "./embedded_shaders";
+import {vec3, mat4} from "gl-matrix";
+import {saveAs} from 'file-saver';
+import {imageDataToTensor, runInference, getImageTensorFromPath, cleanRecurrentState} from "./inference";
+import {InferenceSession} from "onnxruntime-web/webgpu";
 
 (async () => {
-    function runBenchmark(benchmark)
-    {
+    function runBenchmark(benchmark) {
         requestBenchmark = benchmark;
     }
 
-    function saveScreenShotButton()
-    {
+    function saveScreenShotButton() {
         saveScreenshot = true;
     }
 
     // Assumes the input renderTarget and outCanvas have the same image dimensions
-    async function takeScreenshot(device, name, renderTarget, imageBuffer, outCanvas)
-    {
+    async function takeScreenshot(device, name, renderTarget, imageBuffer, outCanvas) {
         var commandEncoder = device.createCommandEncoder();
         commandEncoder.copyTextureToBuffer({texture: renderTarget},
-                                        {buffer: imageBuffer, bytesPerRow: outCanvas.width * 4},
-                                        [outCanvas.width, outCanvas.height, 1]);
+            {buffer: imageBuffer, bytesPerRow: outCanvas.width * 4},
+            [outCanvas.width, outCanvas.height, 1]);
         device.queue.submit([commandEncoder.finish()]);
         await device.queue.onSubmittedWorkDone();
 
@@ -36,7 +33,7 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
         var imgData = context.createImageData(outCanvas.width, outCanvas.height);
         imgData.data.set(imageReadbackArray);
         context.putImageData(imgData, 0, 0);
-        outCanvas.toBlob(function(b) {
+        outCanvas.toBlob(function (b) {
             saveAs(b, `${name}.png`);
         }, "image/png");
 
@@ -67,11 +64,32 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
     var requestBenchmark = null;
     var saveScreenshot = false;
 
+    var benchmarkConfigs = generateBenchmarkConfigurations();
+
     var dataset = datasets.skull;
+    let autobenchmarkIndex = -1;
     if (window.location.hash) {
-        var name = decodeURI(window.location.hash.substr(1));
-        console.log(`Linked to data set ${name}`);
-        dataset = datasets[name];
+        var urlParams = window.location.hash.substring(1).split("&");
+        for (let i = 0; i < urlParams.length; ++i) {
+            let str = decodeURI(urlParams[i]);
+            if (str.startsWith("dataset=")) {
+                let name = str.split("=")[1];
+                console.log(`Linked to data set ${name}`);
+                dataset = datasets[name];
+            } else if (str.startsWith("autobenchmark=")) {
+                autobenchmarkIndex = parseInt(str.split("=")[1]);
+                console.log(`Linked to autobenchmark ${autobenchmarkIndex}`);
+            }
+        }
+    }
+
+    let autobenchmarkConfig = null;
+    if (autobenchmarkIndex > -1) {
+        autobenchmarkConfig = benchmarkConfigs[autobenchmarkIndex];
+        console.log(`Running autobenchmark`);
+        console.log(autobenchmarkConfig);
+        dataset = datasets[autobenchmarkConfig.dataset];
+        console.log(dataset);
     }
 
     var volumeDims = getVolumeDimensions(dataset.name);
@@ -83,7 +101,7 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
         volumeURL = "/models/bcmc-data/" + zfpDataName;
     }
     var compressedData =
-        await fetch(volumeURL).then((res) => res.arrayBuffer().then(function(arr) {
+        await fetch(volumeURL).then((res) => res.arrayBuffer().then(function (arr) {
             return new Uint8Array(arr);
         }));
 
@@ -95,7 +113,11 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
     var resolutionDims = {"1080": [1920, 1088], "720": [1280, 720], "360": [640, 368]};
     var width = resolutionDims[resolution.value][0];
     var height = resolutionDims[resolution.value][1];
-    
+    if (autobenchmarkConfig) {
+        width = resolutionDims[autobenchmarkConfig.resolution][0];
+        height = resolutionDims[autobenchmarkConfig.resolution][1];
+    }
+
     var imageBuffer = device.createBuffer({
         size: width * height * 4,
         usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
@@ -128,9 +150,9 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
     var recordVisibleBlocksUI = document.getElementById("recordVisibleBlocks")
 
     var session;
-    try { 
-        session = await InferenceSession.create(`./noof${width}.onnx`, 
-            { executionProviders: ['webgpu'], graphOptimizationLevel: 'all'});
+    try {
+        session = await InferenceSession.create(`./noof${width}.onnx`,
+            {executionProviders: ['webgpu'], graphOptimizationLevel: 'all'});
         console.log(session);
         var imageReadbackArray = new Uint8ClampedArray(width * height);
         var inputTensor = imageDataToTensor(imageReadbackArray, [1, 3, height, width]);
@@ -138,8 +160,13 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
         console.log(e);
     }
 
+    let completenessThreshold = document.getElementById("completenessThreshold");
     var outCanvas = document.getElementById("out-canvas");
     var headstartSlider = document.getElementById("startSpecCount");
+    if (autobenchmarkConfig) {
+        completenessThreshold.value = autobenchmarkConfig.imageCompleteness;
+        headstartSlider.value = autobenchmarkConfig.startSpecCount;
+    }
     var volumeRC =
         new VolumeRaycaster(device, width, height, recordVisibleBlocksUI, enableSpeculationUI, parseInt(headstartSlider.value));
 
@@ -181,8 +208,8 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
             usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
         });
 
-        session = await InferenceSession.create(`./noof${width}.onnx`, 
-            { executionProviders: ['webgpu'], graphOptimizationLevel: 'all'});
+        session = await InferenceSession.create(`./noof${width}.onnx`,
+            {executionProviders: ['webgpu'], graphOptimizationLevel: 'all'});
         cleanRecurrentState();
     };
     headstartSlider.onchange = async () => {
@@ -224,18 +251,16 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
     var currentIsovalue = isovalueSlider.value;
 
     var cacheInfo = document.getElementById("cacheInfo");
-    var displayCacheInfo = function() {
+    var displayCacheInfo = function () {
         var percentActive = (volumeRC.numVisibleBlocks / volumeRC.totalBlocks) * 100;
-        cacheInfo.innerHTML = `Cache Space: ${
-      volumeRC.lruCache.cacheSize
-    } blocks
+        cacheInfo.innerHTML = `Cache Space: ${volumeRC.lruCache.cacheSize
+            } blocks
             (${(
-              (volumeRC.lruCache.cacheSize / volumeRC.totalBlocks) *
-              100
+                (volumeRC.lruCache.cacheSize / volumeRC.totalBlocks) *
+                100
             ).toFixed(2)} %
             of ${volumeRC.totalBlocks} total blocks)<br/>
-            # Cache Slots Available ${
-              volumeRC.lruCache.displayNumSlotsAvailable}<br/>
+            # Cache Slots Available ${volumeRC.lruCache.displayNumSlotsAvailable}<br/>
             <b>For this Pass:</b><br/>
             # Newly Decompressed: ${volumeRC.newDecompressed}<br/>
             # Visible Blocks: ${volumeRC.numVisibleBlocks}
@@ -283,7 +308,7 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
     var cameraChanged = true;
 
     var controller = new Controller();
-    controller.mousemove = function(prev, cur, evt) {
+    controller.mousemove = function (prev, cur, evt) {
         if (evt.buttons == 1) {
             cameraChanged = true;
             camera.rotate(prev, cur);
@@ -296,14 +321,14 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
             totalTimeMS = 0;
         }
     };
-    controller.wheel = function(amt) {
+    controller.wheel = function (amt) {
         cameraChanged = true;
         camera.zoom(amt * 0.05);
         numFrames = 0;
         totalTimeMS = 0;
     };
     controller.pinch = controller.wheel;
-    controller.twoFingerDrag = function(drag) {
+    controller.twoFingerDrag = function (drag) {
         cameraChanged = true;
         camera.pan(drag);
         numFrames = 0;
@@ -311,7 +336,7 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
     };
     controller.registerForCanvas(canvas);
 
-    var animationFrame = function() {
+    var animationFrame = function () {
         var resolve = null;
         var promise = new Promise((r) => (resolve = r));
         window.requestAnimationFrame(resolve);
@@ -370,6 +395,11 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
 
     var perfStats = [];
 
+    if (autobenchmarkConfig) {
+        requestBenchmark = "random";
+        document.getElementById("infer").checked = true;
+    }
+
     var recomputeSurface = true;
     var surfaceDone = false;
     var averageComputeTime = 0;
@@ -412,9 +442,27 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
         if (currentBenchmark && surfaceDone) {
             if (!currentBenchmark.run()) {
                 var blob = new Blob([JSON.stringify(perfStats)], {type: "text/plain"});
-                saveAs(blob, `perf-${dataset.name}-${currentBenchmark.name}.json`);
+                let outputName = `perf-${dataset.name}-${currentBenchmark.name}.json`;
+                if (autobenchmarkConfig) {
+                    outputName = `perf-${dataset.name}-${currentBenchmark.name}` +
+                        `-${autobenchmarkConfig.resolution}p` +
+                        `-${autobenchmarkConfig.startSpecCount}ssc` +
+                        `-${autobenchmarkConfig.imageCompleteness}ic.json`;
+                }
+                saveAs(blob, outputName);
 
                 currentBenchmark = null;
+
+                // Advance to the next benchmark
+                if (autobenchmarkConfig) {
+                    if (autobenchmarkIndex + 1 < benchmarkConfigs.length) {
+                        window.location.hash = `autobenchmark=${autobenchmarkIndex + 1}`;
+                        window.location.reload();
+                    } else {
+                        console.log('Autobenchmark complete');
+                        document.getElementById("autobenchmark-complete").hidden = false;
+                    }
+                }
             } else if (currentBenchmark.name.includes("cameraOrbit")) {
                 camera = new ArcballCamera(cameraBenchmark.currentPoint, center, up, 4, [
                     canvas.width,
@@ -494,39 +542,39 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
 
             if (document.getElementById("outputImages").checked) {
                 // if (volumeRC.numPasses == 1 || surfaceDone){
-                    var filename = dataset.name.replace(/_/g, '').substring(0, 5);
-                    if (currentBenchmark) {
-                        if (currentBenchmark.name.includes("rotate")) {
-                            filename = filename + "_seq" + cameraBenchmark.renderID + "_" + cameraBenchmark.iteration;
-                            filename += "_" + Math.floor(volumeRC.imageCompleteness * 100);
-                            if (surfaceDone) {
-                                filename += "_ref";
-                            } else {
-                                filename += `_${String(volumeRC.numPasses).padStart(4,'0')}spp`;
-                            }
+                var filename = dataset.name.replace(/_/g, '').substring(0, 5);
+                if (currentBenchmark) {
+                    if (currentBenchmark.name.includes("rotate")) {
+                        filename = filename + "_seq" + cameraBenchmark.renderID + "_" + cameraBenchmark.iteration;
+                        filename += "_" + Math.floor(volumeRC.imageCompleteness * 100);
+                        if (surfaceDone) {
+                            filename += "_ref";
                         } else {
-                            filename += volumeRC.renderID + "_" + String(volumeRC.numPasses).padStart(4,'0');
+                            filename += `_${String(volumeRC.numPasses).padStart(4, '0')}spp`;
                         }
+                    } else {
+                        filename += volumeRC.renderID + "_" + String(volumeRC.numPasses).padStart(4, '0');
                     }
-                    else {
-                        filename += volumeRC.renderID + "_" + String(volumeRC.numPasses).padStart(4,'0');
-                    }
-                    await takeScreenshot(
-                        device,
-                        filename,
-                        volumeRC.renderTarget,
-                        imageBuffer,
-                        document.getElementById('out-canvas'));
+                }
+                else {
+                    filename += volumeRC.renderID + "_" + String(volumeRC.numPasses).padStart(4, '0');
+                }
+                await takeScreenshot(
+                    device,
+                    filename,
+                    volumeRC.renderTarget,
+                    imageBuffer,
+                    document.getElementById('out-canvas'));
                 // }
             }
             if (document.getElementById("infer").checked && surfaceDone) {
                 var commandEncoder = device.createCommandEncoder();
                 commandEncoder.copyTextureToBuffer({texture: volumeRC.renderTarget},
-                                                {buffer: imageBuffer, bytesPerRow: width * 4},
-                                                [width, height, 1]);
+                    {buffer: imageBuffer, bytesPerRow: width * 4},
+                    [width, height, 1]);
                 device.queue.submit([commandEncoder.finish()]);
                 await device.queue.onSubmittedWorkDone();
-        
+
                 await imageBuffer.mapAsync(GPUMapMode.READ);
                 var imageReadbackArray = new Uint8ClampedArray(imageBuffer.getMappedRange());
                 var inputTensor = imageDataToTensor(imageReadbackArray, [1, 3, height, width]);
@@ -552,7 +600,7 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
                     // let idata = ctx.createImageData(canvas.width, canvas.height);
                     // idata.data.set(textureData);
                     // ctx.putImageData(idata, 0, 0);
-    
+
                     var start = new Date();
                     for (var i = 0; i < width * height; i++) {
                         textureData[i * 4] = results[i] * 255;
@@ -561,10 +609,10 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
                         textureData[i * 4 + 3] = 255;
                     }
                     device.queue.writeTexture(
-                        { texture: volumeRC.renderTarget }, 
-                        textureData, 
-                        { bytesPerRow: width * 4 }, 
-                        { width: width, height: height}
+                        {texture: volumeRC.renderTarget},
+                        textureData,
+                        {bytesPerRow: width * 4},
+                        {width: width, height: height}
                     );
                     await device.queue.onSubmittedWorkDone();
                     var end = new Date();
@@ -577,17 +625,18 @@ import { InferenceSession } from "onnxruntime-web/webgpu";
             if (surfaceDone) {
                 perfStats.push(
                     {
-                        "isovalue": currentIsovalue, "stats": volumeRC.surfacePerfStats, "inferenceTime": inferenceTime});
+                        "isovalue": currentIsovalue, "stats": volumeRC.surfacePerfStats, "inferenceTime": inferenceTime
+                    });
             }
 
         }
         if (saveScreenshot) {
             saveScreenshot = false;
             await takeScreenshot(device,
-                                 `${dataset.name}_prog_iso`,
-                                 volumeRC.renderTarget,
-                                 imageBuffer,
-                                 document.getElementById('out-canvas'));
+                `${dataset.name}_prog_iso`,
+                volumeRC.renderTarget,
+                imageBuffer,
+                document.getElementById('out-canvas'));
         }
 
         // Blit the image rendered by the raycaster onto the screen

--- a/src/app.js
+++ b/src/app.js
@@ -65,6 +65,7 @@ import {InferenceSession} from "onnxruntime-web/webgpu";
     var saveScreenshot = false;
 
     var benchmarkConfigs = generateBenchmarkConfigurations();
+    console.log(`# of benchmarkConfigs to run ${benchmarkConfigs.length}`);
 
     var dataset = datasets.skull;
     let autobenchmarkIndex = -1;
@@ -90,6 +91,10 @@ import {InferenceSession} from "onnxruntime-web/webgpu";
         console.log(autobenchmarkConfig);
         dataset = datasets[autobenchmarkConfig.dataset];
         console.log(dataset);
+
+        document.getElementById("autobenchmark-status-div").hidden = false;
+        document.getElementById("autobenchmark-status").innerHTML =
+            `Autobenchmark ${autobenchmarkIndex + 1}/${benchmarkConfigs.length}`;
     }
 
     var volumeDims = getVolumeDimensions(dataset.name);
@@ -460,7 +465,7 @@ import {InferenceSession} from "onnxruntime-web/webgpu";
                         window.location.reload();
                     } else {
                         console.log('Autobenchmark complete');
-                        document.getElementById("autobenchmark-complete").hidden = false;
+                        document.getElementById("autobenchmark-status").innerHTML = "Autobenchmark Complete!";
                     }
                 }
             } else if (currentBenchmark.name.includes("cameraOrbit")) {

--- a/src/run_benchmark.js
+++ b/src/run_benchmark.js
@@ -1,9 +1,10 @@
-import { vec3 } from "gl-matrix";
-const benchmarkIterations = 100;
+import {vec3} from "gl-matrix";
+import {datasets} from "./volumes";
+const benchmarkIterations = 20;
 const cameraIterations = 10;
 const rotateIterations = 10;
 
-export var RandomIsovalueBenchmark = function(isovalueSlider, range) {
+export var RandomIsovalueBenchmark = function (isovalueSlider, range) {
     this.name = "random";
     this.iteration = 0;
     this.isovalueSlider = isovalueSlider;
@@ -11,7 +12,7 @@ export var RandomIsovalueBenchmark = function(isovalueSlider, range) {
     this.numIterations = benchmarkIterations;
 };
 
-RandomIsovalueBenchmark.prototype.run = function() {
+RandomIsovalueBenchmark.prototype.run = function () {
     if (this.iteration == this.numIterations) {
         return false;
     }
@@ -21,11 +22,11 @@ RandomIsovalueBenchmark.prototype.run = function() {
     return true;
 };
 
-RandomIsovalueBenchmark.prototype.reset = function() {
+RandomIsovalueBenchmark.prototype.reset = function () {
     this.iteration = 0;
 };
 
-export var SweepIsovalueBenchmark = function(isovalueSlider, range, sweepUp) {
+export var SweepIsovalueBenchmark = function (isovalueSlider, range, sweepUp) {
     this.iteration = 0;
     this.isovalueSlider = isovalueSlider;
     this.range = range;
@@ -40,7 +41,7 @@ export var SweepIsovalueBenchmark = function(isovalueSlider, range, sweepUp) {
     }
 };
 
-SweepIsovalueBenchmark.prototype.run = function() {
+SweepIsovalueBenchmark.prototype.run = function () {
     if (this.iteration == this.numIterations) {
         return false;
     }
@@ -56,12 +57,12 @@ SweepIsovalueBenchmark.prototype.run = function() {
 };
 
 // ManualSingleBenchmark just re-runs whatever current isovalue we have picked
-export var ManualSingleBenchmark = function() {
+export var ManualSingleBenchmark = function () {
     this.done = false;
     this.name = "manualSingle";
 };
 
-ManualSingleBenchmark.prototype.run = function() {
+ManualSingleBenchmark.prototype.run = function () {
     if (this.done) {
         return false;
     }
@@ -69,22 +70,22 @@ ManualSingleBenchmark.prototype.run = function() {
     return true;
 };
 
-ManualSingleBenchmark.prototype.reset = function() {
+ManualSingleBenchmark.prototype.reset = function () {
     this.done = false;
 };
 
-SweepIsovalueBenchmark.prototype.reset = function() {
+SweepIsovalueBenchmark.prototype.reset = function () {
     this.iteration = 0;
 };
 
-export var CameraOrbitBenchmark = function(radius) {
+export var CameraOrbitBenchmark = function (radius) {
     this.iteration = 0;
     this.name = "cameraOrbit";
     this.numIterations = cameraIterations;
     this.radius = radius;
 };
 
-CameraOrbitBenchmark.prototype.run = function() {
+CameraOrbitBenchmark.prototype.run = function () {
     if (this.iteration == this.numIterations) {
         return false;
     }
@@ -103,15 +104,15 @@ CameraOrbitBenchmark.prototype.run = function() {
 
     this.currentPoint = vec3.set(vec3.create(), x, y, z);
     this.iteration += 1;
-    
+
     return true;
 };
 
-CameraOrbitBenchmark.prototype.reset = function() {
+CameraOrbitBenchmark.prototype.reset = function () {
     this.iteration = 0;
 };
 
-export var RotateBenchmark = function(radius, width, height) {
+export var RotateBenchmark = function (radius, width, height) {
     this.iteration = 0;
     this.name = "rotate";
     this.numIterations = rotateIterations;
@@ -135,7 +136,7 @@ export var RotateBenchmark = function(radius, width, height) {
     this.endY = Math.random() * this.height;
 };
 
-RotateBenchmark.prototype.run = function() {
+RotateBenchmark.prototype.run = function () {
     if (this.iteration == this.numIterations) {
         return false;
     }
@@ -148,7 +149,7 @@ RotateBenchmark.prototype.run = function() {
     return true;
 };
 
-RotateBenchmark.prototype.reset = function() {
+RotateBenchmark.prototype.reset = function () {
     this.renderID = Date.now().toString().slice(-6);
     this.iteration = 0;
     var theta = Math.random() * 2 * Math.PI; // Azimuthal angle
@@ -166,14 +167,14 @@ RotateBenchmark.prototype.reset = function() {
     this.endY = Math.random() * this.height;
 };
 
-export var NestedBenchmark = function(outerLoop, innerLoop) {
+export var NestedBenchmark = function (outerLoop, innerLoop) {
     this.name = outerLoop.name + "-" + innerLoop.name;
     this.outerLoop = outerLoop;
     this.innerLoop = innerLoop;
     this.iteration = 0;
 };
 
-NestedBenchmark.prototype.run = function() {
+NestedBenchmark.prototype.run = function () {
     if (this.iteration == 0) {
         this.outerLoop.run();
     }
@@ -186,5 +187,43 @@ NestedBenchmark.prototype.run = function() {
     }
     this.iteration += 1;
     return true;
+}
+
+// Generate the list of benchmark configurations
+// we're going to run in autobenchmark mode
+export function generateBenchmarkConfigurations() {
+    // Do we really need to go up to ssc 8?
+    const startSpecCounts = [1, 2];//, 4, 8];
+    //const resolutions = ["1080", "720", "360"];
+    const resolutions = ["720", "360"];
+    const imageCompleteness = [0.8];
+    const datasets = ["skull",
+        "tacc_turbulence",
+        "magnetic",
+        "kingsnake",
+        "chameleon",
+        "beechnut",
+        "miranda",
+        "jicf_q",
+        "dns_large",
+        "richtmyer_meshkov"
+    ];
+
+    let benchmarks = [];
+    for (const d of datasets) {
+        for (const ic of imageCompleteness) {
+            for (const r of resolutions) {
+                for (const ssc of startSpecCounts) {
+                    benchmarks.push({
+                        dataset: d,
+                        imageCompleteness: ic,
+                        resolution: r,
+                        startSpecCount: ssc
+                    });
+                }
+            }
+        }
+    }
+    return benchmarks;
 }
 

--- a/src/run_benchmark.js
+++ b/src/run_benchmark.js
@@ -193,10 +193,10 @@ NestedBenchmark.prototype.run = function () {
 // we're going to run in autobenchmark mode
 export function generateBenchmarkConfigurations() {
     // Do we really need to go up to ssc 8?
-    const startSpecCounts = [1, 2];//, 4, 8];
+    const startSpecCounts = [1, 2, 4, 8];
     //const resolutions = ["1080", "720", "360"];
     const resolutions = ["720", "360"];
-    const imageCompleteness = [0.8];
+    const imageCompleteness = [0.85];
     const datasets = ["skull",
         "tacc_turbulence",
         "magnetic",

--- a/src/run_benchmark.js
+++ b/src/run_benchmark.js
@@ -1,6 +1,6 @@
 import {vec3} from "gl-matrix";
 import {datasets} from "./volumes";
-const benchmarkIterations = 20;
+const benchmarkIterations = 10;
 const cameraIterations = 10;
 const rotateIterations = 10;
 
@@ -192,11 +192,11 @@ NestedBenchmark.prototype.run = function () {
 // Generate the list of benchmark configurations
 // we're going to run in autobenchmark mode
 export function generateBenchmarkConfigurations() {
-    // Do we really need to go up to ssc 8?
-    const startSpecCounts = [1, 2, 4, 8];
+    // Do we really need to go up to ssc 8? Probably just on the 3080
+    const startSpecCounts = [1, 2, 4];//, 8];
     //const resolutions = ["1080", "720", "360"];
     const resolutions = ["720", "360"];
-    const imageCompleteness = [0.85];
+    const imageCompleteness = [1.0];
     const datasets = ["skull",
         "tacc_turbulence",
         "magnetic",

--- a/src/volume_raycaster.js
+++ b/src/volume_raycaster.js
@@ -1541,7 +1541,7 @@ VolumeRaycaster.prototype.renderSurface = async function(
         var commandEncoder = this.device.createCommandEncoder();
         if (this.speculationEnabled) {
             this.speculationCount =
-                Math.min(Math.floor(this.width * this.height * this.startSpecCount / numRaysActive), this.startSpecCount * 64);
+                Math.min(Math.floor(this.width * this.height * this.startSpecCount / numRaysActive), 64);
         } else {
             this.speculationCount = this.startSpecCount;
         }
@@ -1728,7 +1728,7 @@ VolumeRaycaster.prototype.renderSurface = async function(
             if (this.speculationEnabled) {
                 var commandEncoder = this.device.createCommandEncoder();
                 this.speculationCount =
-                    Math.min(Math.floor(this.width * this.height * this.startSpecCount / numRaysActive), this.startSpecCount * 64);
+                    Math.min(Math.floor(this.width * this.height * this.startSpecCount / numRaysActive), 64);
                 // console.log(`Next pass speculation count is ${this.speculationCount}`);
                 var uploadSpeculationCount = this.device.createBuffer(
                     {size: 4, usage: GPUBufferUsage.COPY_SRC, mappedAtCreation: true});

--- a/src/volumes.js
+++ b/src/volumes.js
@@ -146,3 +146,4 @@ export var getVolumeDimensions = function(filename) {
     var m = filename.match(fileRegex);
     return [parseInt(m[2]), parseInt(m[3]), parseInt(m[4])];
 };
+


### PR DESCRIPTION
This adds the autobenchmark mode we talked about, you can set the URL to: `localhost:8000/#autobenchmark=0` to kick off the set of benchmarks configs computed in `generateBenchmarkConfigurations`. It will automatically advance to the next benchmark by changing the URL and reloading the page after the current one completes.

Try it out and lets make sure all the data we need is being saved in the JSON file, and that the benchmarks are running correctly. I added the resolution, start spec. count, and image completeness threshold to the perf file names (so they don't conflict), and to the perf JSON as a new "config" entry so we can pick that up when plotting it.